### PR TITLE
Clean up and new streaming script check-mode feature.

### DIFF
--- a/doc/csv/error_codes_en_US.csv
+++ b/doc/csv/error_codes_en_US.csv
@@ -1,37 +1,37 @@
-Error Code in v1.1+ ,Error Message in v1.0-, Error Description
-1,Expected command letter,G-code words consist of a letter and a value. Letter was not found.
-2,Bad number format,Missing the expected G-code word value or numeric value format is not valid.
-3,Invalid statement,Grbl '$' system command was not recognized or supported.
-4,Value < 0,Negative value received for an expected positive value.
-5,Setting disabled,Homing cycle failure. Homing is not enabled via settings.
-6,Value < 3 usec,Minimum step pulse time must be greater than 3usec.
-7,EEPROM read fail. Using defaults,An EEPROM read failed. Auto-restoring affected EEPROM to default values.
-8,Not idle,Grbl '$' command cannot be used unless Grbl is IDLE. Ensures smooth operation during a job.
-9,G-code lock,G-code commands are locked out during alarm or jog state.
-10,Homing not enabled,Soft limits cannot be enabled without homing also enabled.
-11,Line overflow,Max characters per line exceeded. Received command line was not executed.
-12,Step rate > 30kHz,Grbl '$' setting value cause the step rate to exceed the maximum supported.
-13,Check Door,Safety door detected as opened and door state initiated.
-14,Line length exceeded,Build info or startup line exceeded EEPROM line length limit. Line not stored.
-15,Travel exceeded,Jog target exceeds machine travel. Jog command has been ignored.
-16,Invalid jog command,Jog command has no '=' or contains prohibited g-code.
-17,Setting disabled,Laser mode requires PWM output.
-20,Unsupported command,Unsupported or invalid g-code command found in block.
-21,Modal group violation,More than one g-code command from same modal group found in block.
-22,Undefined feed rate,Feed rate has not yet been set or is undefined.
-23,Invalid gcode ID:23,G-code command in block requires an integer value.
-24,Invalid gcode ID:24,More than one g-code command that requires axis words found in block.
-25,Invalid gcode ID:25,Repeated g-code word found in block.
-26,Invalid gcode ID:26,No axis words found in block for g-code command or current modal state which requires them.
-27,Invalid gcode ID:27,Line number value is invalid.
-28,Invalid gcode ID:28,G-code command is missing a required value word.
-29,Invalid gcode ID:29,G59.x work coordinate systems are not supported.
-30,Invalid gcode ID:30,G53 only allowed with G0 and G1 motion modes.
-31,Invalid gcode ID:31,Axis words found in block when no command or current modal state uses them.
-32,Invalid gcode ID:32,G2 and G3 arcs require at least one in-plane axis word.
-33,Invalid gcode ID:33,Motion command target is invalid.
-34,Invalid gcode ID:34,Arc radius value is invalid.
-35,Invalid gcode ID:35,G2 and G3 arcs require at least one in-plane offset word.
-36,Invalid gcode ID:36,Unused value words found in block.
-37,Invalid gcode ID:37,G43.1 dynamic tool length offset is not assigned to configured tool length axis.
-38,Invalid gcode ID:38,Tool number greater than max supported value.
+"Error Code in v1.1+","Error Message in v1.0-","Error Description"
+"1","Expected command letter","G-code words consist of a letter and a value. Letter was not found."
+"2","Bad number format","Missing the expected G-code word value or numeric value format is not valid."
+"3","Invalid statement","Grbl '$' system command was not recognized or supported."
+"4","Value < 0","Negative value received for an expected positive value."
+"5","Setting disabled","Homing cycle failure. Homing is not enabled via settings."
+"6","Value < 3 usec","Minimum step pulse time must be greater than 3usec."
+"7","EEPROM read fail. Using defaults","An EEPROM read failed. Auto-restoring affected EEPROM to default values."
+"8","Not idle","Grbl '$' command cannot be used unless Grbl is IDLE. Ensures smooth operation during a job."
+"9","G-code lock","G-code commands are locked out during alarm or jog state."
+"10","Homing not enabled","Soft limits cannot be enabled without homing also enabled."
+"11","Line overflow","Max characters per line exceeded. Received command line was not executed."
+"12","Step rate > 30kHz","Grbl '$' setting value cause the step rate to exceed the maximum supported."
+"13","Check Door","Safety door detected as opened and door state initiated."
+"14","Line length exceeded","Build info or startup line exceeded EEPROM line length limit. Line not stored."
+"15","Travel exceeded","Jog target exceeds machine travel. Jog command has been ignored."
+"16","Invalid jog command","Jog command has no '=' or contains prohibited g-code."
+"17","Setting disabled","Laser mode requires PWM output."
+"20","Unsupported command","Unsupported or invalid g-code command found in block."
+"21","Modal group violation","More than one g-code command from same modal group found in block."
+"22","Undefined feed rate","Feed rate has not yet been set or is undefined."
+"23","Invalid gcode ID:23","G-code command in block requires an integer value."
+"24","Invalid gcode ID:24","More than one g-code command that requires axis words found in block."
+"25","Invalid gcode ID:25","Repeated g-code word found in block."
+"26","Invalid gcode ID:26","No axis words found in block for g-code command or current modal state which requires them."
+"27","Invalid gcode ID:27","Line number value is invalid."
+"28","Invalid gcode ID:28","G-code command is missing a required value word."
+"29","Invalid gcode ID:29","G59.x work coordinate systems are not supported."
+"30","Invalid gcode ID:30","G53 only allowed with G0 and G1 motion modes."
+"31","Invalid gcode ID:31","Axis words found in block when no command or current modal state uses them."
+"32","Invalid gcode ID:32","G2 and G3 arcs require at least one in-plane axis word."
+"33","Invalid gcode ID:33","Motion command target is invalid."
+"34","Invalid gcode ID:34","Arc radius value is invalid."
+"35","Invalid gcode ID:35","G2 and G3 arcs require at least one in-plane offset word."
+"36","Invalid gcode ID:36","Unused value words found in block."
+"37","Invalid gcode ID:37","G43.1 dynamic tool length offset is not assigned to configured tool length axis."
+"38","Invalid gcode ID:38","Tool number greater than max supported value."

--- a/doc/log/commit_log_v1.1.txt
+++ b/doc/log/commit_log_v1.1.txt
@@ -1,4 +1,23 @@
 ----------------
+Date: 2017-05-31
+Author: chamnit
+Subject: New nonlinear spindle speed PWM output model and solution. Updated scripts.
+
+[new] A nonlinear spindle speed/PWM output option via a piecewise
+linear fit model. Enabled through config.h and solved by a Python
+script in /doc/script
+
+[new] fit_nonlinear_spindle.py. A solver script that can be run on
+http://repl.it for free. No Python install necessary. All instructions
+are available in the script file comments.
+
+[new] stream.py has been updated to include status reports feedback at
+1 second interval.
+
+[fix] stream.py bug fix with verbose mode disabled.
+
+
+----------------
 Date: 2017-03-24
 Author: Sonny Jeon
 Subject: Added an error code for laser mode when VARIABLE_SPINDLE is disabled.

--- a/doc/script/stream.py
+++ b/doc/script/stream.py
@@ -18,7 +18,7 @@ CHANGELOG:
   write mode via simple streaming method. MIT-licensed.
 
 TODO: 
-- Add runtime command capabilities
+- Add realtime control commands during streaming.
 
 ---------------------
 The MIT License (MIT)
@@ -69,6 +69,8 @@ parser.add_argument('-q','--quiet',action='store_true', default=False,
         help='suppress output text')
 parser.add_argument('-s','--settings',action='store_true', default=False, 
         help='settings write mode')        
+parser.add_argument('-c','--check',action='store_true', default=False,
+        help='stream in check mode')
 args = parser.parse_args()
 
 # Periodic timer to query for status reports
@@ -89,14 +91,30 @@ verbose = True
 if args.quiet : verbose = False
 settings_mode = False
 if args.settings : settings_mode = True
+check_mode = False
+if args.check : check_mode = True
 
 # Wake up grbl
-print "Initializing grbl..."
+print "Initializing Grbl..."
 s.write("\r\n\r\n")
 
 # Wait for grbl to initialize and flush startup text in serial input
 time.sleep(2)
 s.flushInput()
+
+if check_mode :
+    print "Enabling Grbl Check-Mode: SND: [$C]",
+    s.write("$C\n")
+    while 1:
+        grbl_out = s.readline().strip() # Wait for grbl response with carriage return
+        if grbl_out.find('error') >= 0 :
+            print "REC:",grbl_out
+            print "  Failed to set Grbl check-mode. Aborting..."
+            quit()
+        elif grbl_out.find('ok') >= 0 :
+            if verbose: print 'REC:',grbl_out
+            break
+
 start_time = time.time();
 
 # Start status report periodic timer
@@ -107,6 +125,7 @@ if ENABLE_STATUS_REPORTS :
 
 # Stream g-code to grbl
 l_count = 0
+error_count = 0
 if settings_mode:
     # Send settings file via simple call-response streaming method. Settings must be streamed
     # in this manner since the EEPROM accessing cycles shut-off the serial interrupt.
@@ -115,15 +134,19 @@ if settings_mode:
         l_count += 1 # Iterate line counter    
         # l_block = re.sub('\s|\(.*?\)','',line).upper() # Strip comments/spaces/new line and capitalize
         l_block = line.strip() # Strip all EOL characters for consistency
-        if verbose: print 'SND: ' + str(l_count) + ':' + l_block,
+        if verbose: print "SND>"+str(l_count)+": \"" + l_block + "\""
         s.write(l_block + '\n') # Send g-code block to grbl
         while 1:
             grbl_out = s.readline().strip() # Wait for grbl response with carriage return
-            if grbl_out.find('ok') < 0 and grbl_out.find('error') < 0 :
-                print "\n  Debug: ",grbl_out,
-            else : 
-                if verbose: print 'REC:',grbl_out
+            if grbl_out.find('ok') >= 0 :
+                if verbose: print "  REC<"+str(l_count)+": \""+grbl_out+"\""
                 break
+            elif grbl_out.find('error') >= 0 :
+                if verbose: print "  REC<"+str(l_count)+": \""+grbl_out+"\""
+                error_count += 1
+                break
+            else:
+                print "    MSG: \""+grbl_out+"\""
 else:    
     # Send g-code program via a more agressive streaming protocol that forces characters into
     # Grbl's serial read buffer to ensure Grbl has immediate access to the next g-code command
@@ -141,22 +164,38 @@ else:
         while sum(c_line) >= RX_BUFFER_SIZE-1 | s.inWaiting() :
             out_temp = s.readline().strip() # Wait for grbl response
             if out_temp.find('ok') < 0 and out_temp.find('error') < 0 :
-                print "  Debug: ",out_temp # Debug response
+                print "    MSG: \""+out_temp+"\"" # Debug response
             else :
-                grbl_out += out_temp;
+                if out_temp.find('error') >= 0 : error_count += 1
                 g_count += 1 # Iterate g-code counter
-                grbl_out += str(g_count); # Add line finished indicator
+                if verbose: print "  REC<"+str(g_count)+": \""+out_temp+"\""
                 del c_line[0] # Delete the block character count corresponding to the last 'ok'
         s.write(l_block + '\n') # Send g-code block to grbl
-        if verbose: print "BUF: " + str(sum(c_line)) + " SND: " + str(l_count) + " [" + l_block + "] REC: " + grbl_out
+        if verbose: print "SND>"+str(l_count)+": \"" + l_block + "\""
+    # Wait until all responses have been received.
+    while l_count > g_count :
+        out_temp = s.readline().strip() # Wait for grbl response
+        if out_temp.find('ok') < 0 and out_temp.find('error') < 0 :
+            print "    MSG: \""+out_temp+"\"" # Debug response
+        else :
+            if out_temp.find('error') >= 0 : error_count += 1
+            g_count += 1 # Iterate g-code counter
+            del c_line[0] # Delete the block character count corresponding to the last 'ok'
+            if verbose: print "  REC<"+str(g_count)+": \""+out_temp + "\""
 
 # Wait for user input after streaming is completed
-print "G-code streaming finished!"
+print "\nG-code streaming finished!"
 end_time = time.time();
 is_run = False;
 print " Time elapsed: ",end_time-start_time,"\n"
-print "WARNING: Wait until grbl completes buffered g-code blocks before exiting."
-raw_input("  Press <Enter> to exit and disable grbl.") 
+if check_mode :
+    if error_count > 0 :
+        print "CHECK FAILED:",error_count,"errors found! See output for details.\n"
+    else :
+        print "CHECK PASSED: No errors found in g-code program.\n"
+else :
+   print "WARNING: Wait until Grbl completes buffered g-code blocks before exiting."
+   raw_input("  Press <Enter> to exit and disable Grbl.") 
 
 # Close file and serial port
 f.close()

--- a/grbl/grbl.h
+++ b/grbl/grbl.h
@@ -23,7 +23,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1f"
-#define GRBL_VERSION_BUILD "20170531"
+#define GRBL_VERSION_BUILD "20170717"
 
 // Define standard libraries used by Grbl.
 #include <avr/io.h>

--- a/grbl/main.c
+++ b/grbl/main.c
@@ -31,6 +31,9 @@ volatile uint8_t sys_rt_exec_state;   // Global realtime executor bitflag variab
 volatile uint8_t sys_rt_exec_alarm;   // Global realtime executor bitflag variable for setting various alarms.
 volatile uint8_t sys_rt_exec_motion_override; // Global realtime executor bitflag variable for motion-based overrides.
 volatile uint8_t sys_rt_exec_accessory_override; // Global realtime executor bitflag variable for spindle/coolant overrides.
+#ifdef DEBUG
+  volatile uint8_t sys_rt_exec_debug;
+#endif
 
 
 int main(void)


### PR DESCRIPTION
[new] The stream.py streaming script now has a check-mode option, where it will place Grbl in $C check mode automatically and then stream the g-code program. It's a very fast way to check if the g-code program has any errors.

[fix] The debug variable was not initialized if the debug option was enabled in config.h

[fix] Updated error_codes CSV file to the same format as the others.